### PR TITLE
[FEAT] Backoff throttle strategy

### DIFF
--- a/.env_example
+++ b/.env_example
@@ -5,3 +5,8 @@ MAIN_CHANNEL_ID=
 
 #TIME IN SECONDS TO THROTTLE REQUESTS TO BOT
 MSG_THROTTLE_TIME=30
+
+#
+# The number of retries before sending a direct message to insistent users
+#
+MSG_RETRY_THRESHOLD=3

--- a/.env_example
+++ b/.env_example
@@ -1,9 +1,16 @@
+#
+# Discord bot token
+#
 BOT_TOKEN=
 
-#MAIN_CHANNEL_ID: TO WHERE THE GENERIC MESSAGES ARE SENT SUCH AS HELLO OR GOODBYE
+#
+# The channel to where generic messages (Hello/Goodbye) should be sent
+#
 MAIN_CHANNEL_ID=
 
-#TIME IN SECONDS TO THROTTLE REQUESTS TO BOT
+#
+# Time (in seconds) the bot should ignore requests from users
+#
 MSG_THROTTLE_TIME=30
 
 #

--- a/src/events/message.js
+++ b/src/events/message.js
@@ -28,7 +28,8 @@ module.exports = async message => {
 
     if (gibberish.length > 0) {
       const attachment = new Attachment(getReservedImage('angryPepe'));
-      message.channel.send('**MANO SO UMA TAG DE CADA VEZ NE!!**', {
+
+      message.channel.send('**EI _BORDA_, UMA TAG DE CADA VEZ, OK?!?!**', {
         files: [attachment],
       });
 

--- a/src/events/message.js
+++ b/src/events/message.js
@@ -5,10 +5,10 @@ const { allowedTags } = require('../boot');
 const retries = new Map();
 
 function throttleUser(
-    author,
-    callback,
-    throttleTime = process.env.MSG_THROTTLE_TIME || 30,
-    retryThreshold = process.env.MSG_RETRY_THRESHOLD || 3
+  author,
+  callback,
+  throttleTime = process.env.MSG_THROTTLE_TIME || 30,
+  retryThreshold = process.env.MSG_RETRY_THRESHOLD || 3,
 ) {
   if (retries.has(author.username)) {
     const retryCount = retries.get(author.username) + 1;
@@ -26,7 +26,9 @@ function throttleUser(
     }
 
     if (retryCount >= retryThreshold) {
-      author.send('_Borda_, fizeste '+retryCount+' pedidos nos últimos '+throttleTime+' segundos. Vamos evitar _flood_ no canal, OK?');
+      author.send(
+        `_Borda_, fizeste ${retryCount} pedidos nos últimos ${throttleTime} segundos. Vamos evitar _flood_ no canal, OK?`,
+      );
 
       return;
     }


### PR DESCRIPTION
This pull request adds the ability to keep track of the number of retries a user has made in the last N seconds, sending direct messages to those who abuse the service.